### PR TITLE
商品出品機能

### DIFF
--- a/app/assets/stylesheets/_error_messages.scss
+++ b/app/assets/stylesheets/_error_messages.scss
@@ -1,0 +1,4 @@
+.error_numbers {
+  font-size: 18px;
+  color: red;
+}

--- a/app/assets/stylesheets/_error_messages.scss
+++ b/app/assets/stylesheets/_error_messages.scss
@@ -1,4 +1,5 @@
 .error_numbers {
   font-size: 18px;
   color: red;
+  font-weight: bold;
 }

--- a/app/assets/stylesheets/_product.scss
+++ b/app/assets/stylesheets/_product.scss
@@ -21,6 +21,10 @@
       margin: 0 auto;
       font-size: 14px;
       padding: 20px 0;
+      p {
+        color: red;
+        font-weight: bold;
+      }
       %h1 {
         padding-top: 20px;
       }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "devises";
 @import "index";
 @import "product.scss";
+@import "error_messages.scss";

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,6 +15,7 @@ class ProductsController < ApplicationController
     if @product.save
       redirect_to root_path
     else
+      @product.product_images.new
       render :new
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,12 +13,16 @@ class Product < ApplicationRecord
   belongs_to_active_hash :preparation_day
   # 上記大野商品出品機能のため追記
 
+  
+  validates_associated :product_images
   # バリデーション
+  validates :name, presence: true, length: {maximum: 40}
+  validates :description, presence: true, length: {maximum: 1000}
   validates :prefecture, presence: true
   validates :condition, presence: true
   validates :postage, presence: true
   validates :preparation_day, presence: true
-  validates :pricing, presence: true
+  validates :pricing, presence: true, numericality: { only_integer: true, greater_than: 300, less_than: 10000000}
   validates :product_images, presence: true
 
  

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,19 @@ class User < ApplicationRecord
   validates :firstname, :lastname, :firstname_kana, :lastname_kana, presence: true, format: { with: /\A[一-龥ぁ-ん]/}
   validates :birthday, presence: true
   has_one :domicile
+
   # 大野商品出品で追記↓
   has_many :products
+
+  # 販売中(sellerが自分で、buyer_id無い時)
+  has_many :selling_products, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Product"
+
+  # 売却済み(sellerが自分で、buyer_idに何かある時時)
+  has_many :sold_products, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Product"
+
+  # 自分が買った商品（自分のID＝buyer_idの時）
+  has_many :purchased_products, foreign_key: "buyer_id", class_name: "Product"
+
+
+
 end

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,6 +1,6 @@
 = form_with(model: @product, local: true) do |form|
   - if @product.errors.any?
     #error_explanation
-      %h2{:style => "color: red;"}
+      %h2
         = pluralize(@product.errors.count, "箇所")
         記入・選択漏れがあります:

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,0 +1,6 @@
+= form_with(model: @product, local: true) do |form|
+  - if @product.errors.any?
+    #error_explanation
+      %h2{:style => "color: red;"}
+        = pluralize(@product.errors.count, "箇所")
+        記入・選択漏れがあります:

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,6 +1,6 @@
 = form_with(model: @product, local: true) do |form|
   - if @product.errors.any?
     #error_explanation
-      %h2
+      %h2.error_numbers
         = pluralize(@product.errors.count, "箇所")
-        記入・選択漏れがあります:
+        記入漏れがあります:

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -4,6 +4,7 @@
   .exhibition__page__box
     .exhibition__page__box__in
       = form_for @product do |f|
+        = render 'layouts/error_messages', model: f.object
         %h1
         出品画像
         %span 必須
@@ -15,7 +16,7 @@
                 = image_tag image.src.url, data: { index: i }, width: "100", height: '100'
           = f.fields_for :product_images do |image|
             .js-file_group{"data-index" => image.index}
-              = image.file_field :src, class: 'js-file', required: ""
+              = image.file_field :src, class: 'js-file'
               %br/
               .js-remove 削除
             - if @product.persisted?
@@ -28,12 +29,16 @@
         商品名
         %span 必須
         .form
-          =f.text_field :name, placeholder: "40文字まで", required: ""
+          =f.text_field :name, placeholder: "40文字まで"
+          - if @product.errors.include?(:name)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:name).first
         %h1
         商品の説明
         %span 必須
         .form
-          =f.text_area :description, size: "78%x7", placeholder: "商品の説明 (必須,1,000文字以内) (色、素材、重さ、定価、注意点など)   例) 2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。" , required: ""
+          =f.text_area :description, size: "78%x7", placeholder: "商品の説明 (必須,1,000文字以内) (色、素材、重さ、定価、注意点など)   例) 2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。"
+          - if @product.errors.include?(:description)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:description).first
         %h2
         商品の詳細
         -# %h1
@@ -50,24 +55,32 @@
         商品状態
         %span 必須
         .form
-          =f.collection_select :condition_id, Condition.all, :id, :name, {prompt:"選択してください"}, {class:"", required: ""}
+          =f.collection_select :condition_id, Condition.all, :id, :name, {prompt:"選択してください"}, {class:""}
+          - if @product.errors.include?(:condition)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:condition).first
         %h2
         配送について
         %h1
         配送料の負担
         %span 必須
         .form
-          =f.collection_select :postage_id, Postage.all, :id, :name, {prompt:"選択してください"}, {class:"", required: ""}
+          =f.collection_select :postage_id, Postage.all, :id, :name, {prompt:"選択してください"}, {class:""}
+          - if @product.errors.include?(:postage)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:postage).first
         %h1
         発送元の地域
         %span 必須
         .form
-          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"選択してください"}, {class:"", required: ""}
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"選択してください"}, {class:""}
+          - if @product.errors.include?(:prefecture)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:prefecture).first
         %h1
         発送までの日数
         %span 必須
         .form
-          =f.collection_select :preparation_day_id, PreparationDay.all, :id, :name, {prompt:"選択してください"}, {class:"", required: ""}
+          =f.collection_select :preparation_day_id, PreparationDay.all, :id, :name, {prompt:"選択してください"}, {class:""}
+          - if @product.errors.include?(:preparation_day)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:preparation_day).first
         %h2
         価格(¥300~9,999,999)  
         %h1
@@ -75,7 +88,9 @@
         %span 必須
         .form
           =icon('fas','yen-sign')
-          =f.text_field :pricing, required: ""
+          =f.text_field :pricing
+          - if @product.errors.include?(:pricing)
+            %p{:style => "color: red;"}= @product.errors.full_messages_for(:pricing).first
         .action
           =f.submit "出品する"    
   .newFooter

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -8,7 +8,7 @@
         %h1
         出品画像
         %span 必須
-        %p 最大10枚までアップロードできます
+        %br 最大10枚までアップロードできます
         #image-box
           #previews
             - if @product.persisted?

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -31,14 +31,14 @@
         .form
           =f.text_field :name, placeholder: "40文字まで"
           - if @product.errors.include?(:name)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:name).first
+            %p= @product.errors.full_messages_for(:name).first
         %h1
         商品の説明
         %span 必須
         .form
           =f.text_area :description, size: "78%x7", placeholder: "商品の説明 (必須,1,000文字以内) (色、素材、重さ、定価、注意点など)   例) 2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。合わせやすいのでおすすめです。"
           - if @product.errors.include?(:description)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:description).first
+            %p= @product.errors.full_messages_for(:description).first
         %h2
         商品の詳細
         -# %h1
@@ -57,7 +57,7 @@
         .form
           =f.collection_select :condition_id, Condition.all, :id, :name, {prompt:"選択してください"}, {class:""}
           - if @product.errors.include?(:condition)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:condition).first
+            %p= @product.errors.full_messages_for(:condition).first
         %h2
         配送について
         %h1
@@ -66,21 +66,21 @@
         .form
           =f.collection_select :postage_id, Postage.all, :id, :name, {prompt:"選択してください"}, {class:""}
           - if @product.errors.include?(:postage)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:postage).first
+            %p= @product.errors.full_messages_for(:postage).first
         %h1
         発送元の地域
         %span 必須
         .form
           = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt:"選択してください"}, {class:""}
           - if @product.errors.include?(:prefecture)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:prefecture).first
+            %p= @product.errors.full_messages_for(:prefecture).first
         %h1
         発送までの日数
         %span 必須
         .form
           =f.collection_select :preparation_day_id, PreparationDay.all, :id, :name, {prompt:"選択してください"}, {class:""}
           - if @product.errors.include?(:preparation_day)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:preparation_day).first
+            %p= @product.errors.full_messages_for(:preparation_day).first
         %h2
         価格(¥300~9,999,999)  
         %h1
@@ -90,9 +90,9 @@
           =icon('fas','yen-sign')
           =f.text_field :pricing
           - if @product.errors.include?(:pricing)
-            %p{:style => "color: red;"}= @product.errors.full_messages_for(:pricing).first
+            %p= @product.errors.full_messages_for(:pricing).first
         .action
-          =f.submit "出品する"    
+          =f.submit "出品する"
   .newFooter
     .footercontents
       %ul.footerlists

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_050756) do
+ActiveRecord::Schema.define(version: 2020_06_26_015332) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "customer_id", null: false
@@ -59,24 +59,6 @@ ActiveRecord::Schema.define(version: 2020_06_25_050756) do
     t.datetime "updated_at", null: false
     t.index ["buyer_id"], name: "index_products_on_buyer_id"
     t.index ["seller_id"], name: "index_products_on_seller_id"
-  end
-
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname"
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "firstname", null: false
-    t.string "lastname", null: false
-    t.string "firstname_kana", null: false
-    t.string "lastname_kana", null: false
-    t.date "birthday", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# what
商品出品機能：バックエンド
　・複数画像投稿：https://gyazo.com/899856c1d4e6981d4be83321e8cd7e9f
　・出品中/売却済みなどの状態をテーブルで登録：
　　①販売中
　　　https://gyazo.com/a423b19f7a3e1790f1b20694cd40d039
　　②売却済み
　　　https://gyazo.com/fc3bf1e6f14f31cb69f3bb614a458e8b
　　③買った物
　　　https://gyazo.com/33834831fb92767b472b783b23c3855b
　・エラーハンドリング：https://gyazo.com/37ef509d827815bf2910e017b92b14ec
　・バリデーション：上記画像で確認はできますが、render:newで同じページに回帰

# why
本アプリの根幹機能であるため